### PR TITLE
Backend: Dashboard Display & Func Add Category

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -16,16 +16,24 @@
           <h3 class="sidebar-title">Categories</h3>
           <ul class="category-list">
             <li>
-              <a href="/dashboard?category=all" class="category-link">All Tasks</a>
+                <!--            AAA: 把上面取消注释下面注释起来-->
+<!--              <a href="{{ url_for('dashboard', category='all', user_id=request.args.get('user_id')) }}" class="category-link">All Tasks</a>-->
+              <a href="{{ url_for('dashboard', category='all') }}" class="category-link">All Tasks</a>
             </li>
             {% for category in categories %}
             <li>
-              <a href="/dashboard?category={{ category.id }}" class="category-link">{{ category.name }}</a>
+                <!--            AAA: 把上面取消注释下面注释起来-->
+<!--              <a href="{{ url_for('dashboard', category=category.id, user_id=request.args.get('user_id')) }}" class="category-link">-->
+<!--                {{ category.name }}-->
+<!--              </a>-->
+              <a href="{{ url_for('dashboard', category=category.id) }}" class="category-link">{{ category.name }}</a>
             </li>
             {% endfor %}
           </ul>
 
-          <form action="/api/categories" method="POST" class="category-form">
+                <!--            AAA: 把上面取消注释下面注释起来-->
+<!--          <form action="/api/categories" method="POST" class="category-form">-->
+          <form action="{{ url_for('api_add_category') }}" method="POST" class="category-form">
             <input
               type="text"
               name="name"
@@ -33,6 +41,8 @@
               class="category-input"
               required
             />
+              <!--            AAA: 把下面取消注释-->
+<!--            <input type="hidden" name="user_id" value="{{ request.args.get('user_id') or '' }}">-->
             <button type="submit" class="btn-add-category">Add</button>
           </form>
         </div>

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, jsonify
+
+bp = Blueprint("todos_query", __name__)
+
+
+@bp.get("/todos")
+def list_todos():
+    # 先返回一个占位结果，验证路由打通
+    return jsonify(items=[{"id":"demo1","title":"Hello, API is wired up!"}]), 200


### PR DESCRIPTION
What & Why: 1. Dashboard (/dashboard) now uses session/flask-login instead of URL params. Data is scoped to the currently logged-in user. We no longer read user_id from the query string. 2. Categories sidebar shows only categories where user_id == current user. 3. Tasks table supports filtering by ?category=<category_id | category_name>. When tasks store category_id, it’s mapped back to the category name for display. 4. Create category (POST /api/categories)

What changed (high level)
app.py
Added session-based helpers to get current user id; Protected /dashboard and /api/categories with login; Query MongoDB using user_id to fetch categories and tasks; Category filter accepts either ObjectId or category name.

templates/dashboard.html
Removed hidden user_id field; links generated with url_for; Sidebar links pass category= only (no user_id in URL).

Notes / Integration
This aligns with Siqi’s auth work: we read user id from the session/flask-login, not from the URL.

